### PR TITLE
feat: Trims down OCI image

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -1,5 +1,6 @@
 name: sdcore-gnbsim
-base: ubuntu:22.04
+base: bare
+build-base: ubuntu:22.04
 version: '1.3'
 summary: SD-Core gnbsim
 description: SD-Core gnbsim
@@ -19,3 +20,4 @@ parts:
       bin/cmd: bin/gnbsim
     stage-packages:
       - iproute2
+      - libc6


### PR DESCRIPTION
# Description

Trims down OCI image by using bare base. Note that we are not using the libc6 slice but the complete package because we "cannot mix packages and slices in stage-packages in field 'parts.gnbsim'" and we need `iproute2`.

## Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.