### PR TITLE
(FIX) Switching gnbsim source to fork to fix building

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -11,9 +11,9 @@ platforms:
 parts:
   gnbsim:
     plugin: go
-    source: https://github.com/omec-project/gnbsim.git
+    source: https://github.com/Gmerold/gnbsim.git
     source-type: git
-    source-commit: 1caccfcaac9b718d987aff378212614e4fe634fb
+    source-commit: 846b8504395ee5dfeab036306e97bbac747af849
     build-snaps:
       - go/1.18/stable
     organize:


### PR DESCRIPTION
# Description

Original source contains reference to an old `github.com/omec-project/nas` dependency in the `go.sum` file. Because of that, rock fails to build with:
```
Executing action                                                                                                                                                                                                                       
:: + go mod download all                                                                                                                                                                                                               
:: verifying github.com/omec-project/nas@v1.1.1/go.mod: checksum mismatch                                                                                                                                                              
::   downloaded: h1:WRl/gOe8pZATzTk5pHbAcqUuWbmLdVV/jzjnl5lCcJ8=                                                                                                                                                                       
::   go.sum:     h1:gXqi/IZwEGXno26X8wg8ITsAUiemRQ7PkIJOWP1NzGA=                                                                                                                                                                       
::                                                                                                                                                                                                                                     
:: SECURITY ERROR  
```
This PR switches source to a fork with good `go.sum`.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that validate the behaviour of the software.
- [x] I validated that new and existing tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.