### PR TITLE
fix: Update workload version to 1.4.2

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -1,7 +1,7 @@
 name: sdcore-gnbsim
 base: bare
 build-base: ubuntu@22.04
-version: '1.4.0'
+version: '1.4.2'
 summary: SD-Core gnbsim
 description: SD-Core gnbsim
 license: Apache-2.0
@@ -14,7 +14,7 @@ parts:
     plugin: go
     source: https://github.com/omec-project/gnbsim.git
     source-type: git
-    source-tag: v1.4.0
+    source-tag: v1.4.2
     build-snaps:
       - go/1.22/stable
     organize:


### PR DESCRIPTION
# Description

The upstream GNBSIM is updated to fix security error during compilation by PR: https://github.com/omec-project/gnbsim/pull/162.
This PR bumps the workload version to get the fix and solves the issue https://github.com/canonical/sdcore-amf-rock/issues/22.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.